### PR TITLE
Fix: Removed dependency ad-network config line-ending on user os

### DIFF
--- a/Assets/DeltaDNA/Ads/Editor/Networks/AndroidNetworks.cs
+++ b/Assets/DeltaDNA/Ads/Editor/Networks/AndroidNetworks.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using UnityEditor;
 
@@ -150,7 +151,8 @@ namespace DeltaDNA.Ads.Editor {
                     }
                 }
                 
-                config.Save(CONFIG);
+                using (var w = XmlWriter.Create(CONFIG, new XmlWriterSettings { NewLineChars = "\n", Indent = true }) )
+                    config.WriteTo(w);
             }
         }
         

--- a/Assets/DeltaDNA/Ads/Editor/Networks/IosNetworks.cs
+++ b/Assets/DeltaDNA/Ads/Editor/Networks/IosNetworks.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace DeltaDNA.Ads.Editor {
@@ -144,7 +145,8 @@ namespace DeltaDNA.Ads.Editor {
                     }
                 }
                 
-                config.Save(CONFIG);
+                using (var w = XmlWriter.Create(CONFIG, new XmlWriterSettings { NewLineChars = "\n", Indent = true }) )
+                    config.WriteTo(w);
             }
         }
         


### PR DESCRIPTION
Hello!

There are MacOS & Window users in our dev team, and we have some headache with `Dependencies.xml` config for AdNetwork and VCS.

Because `System.Xml.Linq.XDocument` respect os-system line-endings, I fix this problem via using `System.Xml.XmlWriter`

If you need this fix - use it