### PR TITLE
ClientInfo.cs: return manufacturer as "Apple" when building for UNITY_IOS

### DIFF
--- a/Assets/DeltaDNA/Helpers/ClientInfo.cs
+++ b/Assets/DeltaDNA/Helpers/ClientInfo.cs
@@ -367,6 +367,8 @@ namespace DeltaDNA
             return Trim(
                 new AndroidJavaObject("android.os.Build").GetStatic<string>("MANUFACTURER"),
                 72);
+            #if UNITY_IOS && !UNITY_EDITOR
+            return "Apple";
             #else
             return null;
             #endif


### PR DESCRIPTION
Our liveops team noticed that the manufacturer was not reporting on iOS devices.

This patch should fix that.