### PR TITLE
Added a null check to prevent NullReferenceException

### DIFF
--- a/Assets/DeltaDNA/Triggers/EventAction.cs
+++ b/Assets/DeltaDNA/Triggers/EventAction.cs
@@ -72,12 +72,16 @@ namespace DeltaDNA {
         public void Run(){
             bool handledImageMessage = false;
             List<EventActionHandler> handlersWithDefaults = new List<EventActionHandler>(handlers);
-            if (settings.DefaultGameParameterHandler != null){
-                handlersWithDefaults.Add(settings.DefaultGameParameterHandler);
-            }
-            if (settings.DefaultImageMessageHandler != null){
-                handlersWithDefaults.Add(settings.DefaultImageMessageHandler);
-            }
+            
+            if (settings != null) {
+				if (settings.DefaultGameParameterHandler != null){
+	                handlersWithDefaults.Add(settings.DefaultGameParameterHandler);
+	            }
+	            if (settings.DefaultImageMessageHandler != null){
+	                handlersWithDefaults.Add(settings.DefaultImageMessageHandler);
+	            }
+			}
+            
             foreach (var trigger in triggers) {
                 if (trigger.Evaluate(evnt)) {
                     foreach (var handler in handlersWithDefaults) {


### PR DESCRIPTION
A NullReferenceException was occurring when attempting to Run() an un-whitelisted event. DDNAImpl.RecordEvent<T>(T gameEvent):166 returns an empty EventAction when the event given is not whitelisted - that empty EventAction's 'settings' field is null, courtesy of EventAction.CreateEmpty(GameEvent evnt):101. As such, an exception is triggered at EventAction:75 (now 77) when settings.DefaultGameParameterHandler is called. I've added a null check of 'settings' to prevent the exception - expected behavior is now that the empty, un-whitelisted EventAction can be run as normal, handlers intact, without an unhandled exception bubbling further up the stack.