### PR TITLE
Fix FormatException when parsing DateTime

### DIFF
--- a/Assets/DeltaDNA/DDNA.cs
+++ b/Assets/DeltaDNA/DDNA.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -247,11 +248,11 @@ namespace DeltaDNA {
             if (!PlayerPrefs.HasKey(PF_KEY_FIRST_SESSION)) {
                 PlayerPrefs.SetString(
                     PF_KEY_FIRST_SESSION,
-                    DateTime.UtcNow.ToString(Settings.EVENT_TIMESTAMP_FORMAT));
+                    DateTime.UtcNow.ToString(Settings.EVENT_TIMESTAMP_FORMAT, CultureInfo.InvariantCulture));
             }
             PlayerPrefs.SetString(
                 PF_KEY_LAST_SESSION,
-                DateTime.UtcNow.ToString(Settings.EVENT_TIMESTAMP_FORMAT));
+                DateTime.UtcNow.ToString(Settings.EVENT_TIMESTAMP_FORMAT, CultureInfo.InvariantCulture));
 
             if (OnNewSession != null) OnNewSession();
         }


### PR DESCRIPTION
Use CultureInfo.InvariantCulture when converting DateTime to string to fix FormatException when parsing in DDNAImpl.RequestSessionConfiguration