### PR TITLE
Ensure field "spriteMap" is updated on redraw()

### DIFF
--- a/Assets/DeltaDNA/Messaging/ImageMessage.cs
+++ b/Assets/DeltaDNA/Messaging/ImageMessage.cs
@@ -137,6 +137,7 @@ namespace DeltaDNA {
             changer.Init(redraw);
             SpriteMap spriteMap = gameObject.AddComponent<SpriteMap>();
             spriteMap.Build(ddna, configuration);
+            this.spriteMap = spriteMap;
             Show();
         }
 


### PR DESCRIPTION
An exception is currently thrown on the first call to spriteMap.Texture in Show() if spriteMap is null, and the ImageMessage will fail to display. Why might spriteMap be null? Well, if redraw() was called prior to this, the SpriteMap component will have been destroyed as part of the call to Object.Destroy(), and while a new SpriteMap is created in redraw(), the field member 'spriteMap' is not being set to this new component. Hence, any call to redraw() will lead to the exception since redraw() calls Show().

The solution I've presented here is the smallest change to fix the issue, but I think the better solution would be to forgo the local versions of "spriteMap" (which hide the member of the same name, triggering a warning) and replace lines 118 and 138 with "spriteMap = gameObject.AddComponent<SpriteMap>();" so there doesn't have to be an extra step of setting the field to the local - a step that is easy to miss, as in the case of this redraw() method.

Long-term, you might also consider decoupling the creation of the GameObject from the creation of the ImageMessage object, so the user can have the option to display the object sometime after the event that triggered it. At present, a scene change taking place between the event and the call to Show() will destroy the object without a publicly-defined way to get it back. I discovered the issue addressed above while experimenting with making redraw() public so I could display the ImageMessage in such a case.