### PR TITLE
Optimized texture creation for image message

### DIFF
--- a/Assets/DeltaDNA/Helpers/ImageMessageStore.cs
+++ b/Assets/DeltaDNA/Helpers/ImageMessageStore.cs
@@ -58,7 +58,7 @@ namespace DeltaDNA {
                 .GetFiles(cache)
                 .Where(e => GetName(e).Equals(GetName(url)))
                 .Select(e => {
-                    var texture = new Texture2D(2, 2);
+                    var texture = new Texture2D(2, 2, TextureFormat.ARGB32, false);
                     return texture.LoadImage(File.ReadAllBytes(e)) ? texture : null;
                 })
                 .FirstOrDefault();

--- a/Assets/DeltaDNA/Messaging/ImageMessage.cs
+++ b/Assets/DeltaDNA/Messaging/ImageMessage.cs
@@ -236,9 +236,10 @@ namespace DeltaDNA {
                         spriteMap.LoadResource(e => {});
                     }
 
-                    gameObject.AddComponent<Canvas>();
+                    var canvas = gameObject.AddComponent<Canvas>();
                     gameObject.AddComponent<GraphicRaycaster>();
-                    gameObject.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+                    canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+	                 canvas.sortingOrder = 999999;
 
                     if (this.configuration.ContainsKey("shim")) {
                         ShimLayer shimLayer = gameObject.AddComponent<ShimLayer>();


### PR DESCRIPTION
1. Removed copying base texture data for image message layers. Now layers use sprites based on atlas texture. This reduces the use of video memory.
2. The texture is created without mipmapping. This reduces the use of video memory and increases render quality.