### PR TITLE
Properly dispose request objects

### DIFF
--- a/Assets/DeltaDNA/Runtime/Helpers/Network.cs
+++ b/Assets/DeltaDNA/Runtime/Helpers/Network.cs
@@ -108,6 +108,8 @@ namespace DeltaDNA {
                 completionHandler((int)www.responseCode, www.downloadHandler.text, www.error);
             }
 
+            www.Dispose();
+
             #else
 
             WWW www;


### PR DESCRIPTION
Add missing dispose call. UnityWebRequest object must be disposed after request is completed, otherwise UploadHandler will keep its payload in memory forever and cause memory leak.